### PR TITLE
fix: guard convex-dependent prerender paths for builds

### DIFF
--- a/app/ConvexClientProvider.tsx
+++ b/app/ConvexClientProvider.tsx
@@ -3,7 +3,9 @@
 import { ConvexProvider, ConvexReactClient } from "convex/react";
 import { ReactNode } from "react";
 
-const convex = new ConvexReactClient(process.env.NEXT_PUBLIC_CONVEX_URL!);
+const convex = new ConvexReactClient(
+  process.env.NEXT_PUBLIC_CONVEX_URL ?? "https://placeholder.convex.cloud",
+);
 
 export function ConvexClientProvider({ children }: { children: ReactNode }) {
   return <ConvexProvider client={convex}>{children}</ConvexProvider>;

--- a/app/_components/recent-sites.tsx
+++ b/app/_components/recent-sites.tsx
@@ -19,9 +19,13 @@ import { FunctionReturnType } from "convex/server";
 type RecentSite = FunctionReturnType<typeof api.sites.getRecentSites>[number];
 
 export default async function RecentSites() {
+  if (!process.env.NEXT_PUBLIC_CONVEX_URL) {
+    return null;
+  }
+
   const recent_sites: RecentSite[] = await fetchQuery(
     api.sites.getRecentSites,
-    {limit: 32},
+    { limit: 32 },
   );
 
   return (

--- a/app/site/[id]/page.tsx
+++ b/app/site/[id]/page.tsx
@@ -23,6 +23,10 @@ interface SitePageProps {
 }
 
 export default async function SitePage({ params }: SitePageProps) {
+  if (!process.env.NEXT_PUBLIC_CONVEX_URL) {
+    return <NotFound />;
+  }
+
   const { id } = await params;
 
   const full_site_details = await fetchQuery(api.sites.getFullSiteDetails, {
@@ -159,13 +163,25 @@ export default async function SitePage({ params }: SitePageProps) {
 }
 
 export async function generateStaticParams() {
+  if (!process.env.NEXT_PUBLIC_CONVEX_URL) {
+    return [];
+  }
+
   const all_ids = await fetchQuery(api.sites.getAllSiteIds);
-  return all_ids.map((id) => ({ id: id }));
+  return all_ids.map((id) => ({ id }));
 }
 
 export async function generateMetadata({
   params,
 }: SitePageProps): Promise<Metadata> {
+  if (!process.env.NEXT_PUBLIC_CONVEX_URL) {
+    return {
+      title: "Privacy Peek",
+      description: "Full privacy policy analysis.",
+      metadataBase: new URL("https://privacypeek.vercel.app"),
+    };
+  }
+
   const { id } = await params;
 
   const site = await fetchQuery(api.sites.getFullSiteDetails, { site_id: id });

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -3,6 +3,17 @@ import { fetchQuery } from "convex/nextjs";
 import { MetadataRoute } from "next";
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+  if (!process.env.NEXT_PUBLIC_CONVEX_URL) {
+    return [
+      {
+        url: "https://privacypeek.vercel.app",
+        lastModified: new Date(),
+        changeFrequency: "daily",
+        priority: 1,
+      },
+    ];
+  }
+
   const site_ids = await fetchQuery(api.sites.getAllSiteIds);
 
   const sites: MetadataRoute.Sitemap = site_ids.map((id) => {


### PR DESCRIPTION
## Summary
- guard Convex client/provider initialization when NEXT_PUBLIC_CONVEX_URL is unset
- make /site/[id], sitemap generation, and recent-sites queries resilient during static build
- keep runtime behavior unchanged when Convex env is configured

## Validation
- pnpm.cmd lint
- pnpm.cmd build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved app resilience by implementing graceful handling of missing configuration. The application now conditionally bypasses database queries and displays appropriate fallback content or error states when required environment settings are unavailable, preventing runtime failures and ensuring consistent behavior across different deployment scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->