### PR TITLE
feat: add recent sites list view

### DIFF
--- a/app/_components/recent-sites.tsx
+++ b/app/_components/recent-sites.tsx
@@ -10,31 +10,108 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
 import { RequireOnly, SiteDetails } from "@/convex/lib";
 import { cn, formatRelativeTime } from "@/lib/utils";
 import Link from "next/link";
 import ScoreVisualizer from "@/components/ui/score-visualizer";
 import { FunctionReturnType } from "convex/server";
+import { ArrowUpRightIcon } from "lucide-react";
 
 type RecentSite = FunctionReturnType<typeof api.sites.getRecentSites>[number];
 
 export default async function RecentSites() {
   const recent_sites: RecentSite[] = await fetchQuery(
     api.sites.getRecentSites,
-    {limit: 32},
+    { limit: 32 },
   );
 
   return (
-    <section className="flex flex-col gap-2 border-t">
-      <h4>Recently Analyzed</h4>
-
-      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 md:gap-8">
-        {recent_sites &&
-          recent_sites.map((site) => (
-            <SiteCard key={site._id} site_details={site} />
-          ))}
+    <section className="flex flex-col gap-4 border-t pt-4">
+      <div className="flex flex-col gap-1 md:flex-row md:items-end md:justify-between">
+        <div>
+          <h4>Recently Analyzed</h4>
+          <p className="text-sm text-muted-foreground">
+            {recent_sites.length} recent scans, with a compact list for faster skimming.
+          </p>
+        </div>
       </div>
+
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:hidden xl:gap-8">
+        {recent_sites.map((site) => (
+          <SiteCard key={site._id} site_details={site} />
+        ))}
+      </div>
+
+      <RecentSitesTable sites={recent_sites} />
     </section>
+  );
+}
+
+function RecentSitesTable({ sites }: { sites: RecentSite[] }) {
+  return (
+    <div className="hidden overflow-hidden rounded-xl border xl:block">
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Site</TableHead>
+            <TableHead>Domain</TableHead>
+            <TableHead>Analyzed</TableHead>
+            <TableHead className="text-right">Score</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {sites.map((site) => {
+            const safeOverallScore = getSafeOverallScore(site.overall_score);
+
+            return (
+              <TableRow key={site._id}>
+                <TableCell className="font-medium whitespace-normal">
+                  <Link href={`/site/${site._id}`} className="hover:underline">
+                    {site.site_name}
+                  </Link>
+                </TableCell>
+                <TableCell>
+                  <Link
+                    href={site.normalized_base_url}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="inline-flex items-center gap-1 text-muted-foreground hover:text-foreground hover:underline"
+                  >
+                    <span className="max-w-56 truncate">
+                      {getDomainLabel(site.normalized_base_url)}
+                    </span>
+                    <ArrowUpRightIcon className="size-3.5" />
+                  </Link>
+                </TableCell>
+                <TableCell className="text-muted-foreground">
+                  {formatRelativeTime(site.last_analyzed)}
+                </TableCell>
+                <TableCell className="text-right">
+                  <div className="inline-flex items-center gap-2">
+                    <span className="text-sm text-muted-foreground">
+                      {safeOverallScore.toFixed(0)}/100
+                    </span>
+                    <ScoreVisualizer
+                      value={safeOverallScore / 100}
+                      displayNumber={safeOverallScore.toFixed(0)}
+                      size={36}
+                    />
+                  </div>
+                </TableCell>
+              </TableRow>
+            );
+          })}
+        </TableBody>
+      </Table>
+    </div>
   );
 }
 
@@ -52,8 +129,17 @@ export function SiteCard({
     | "category_scores"
   >;
 }) {
-  const { _id, site_name, overall_score, last_analyzed, category_scores } =
-    site_details;
+  const {
+    _id,
+    site_name,
+    overall_score,
+    last_analyzed,
+    category_scores,
+    normalized_base_url,
+  } = site_details;
+
+  const safeOverallScore = getSafeOverallScore(overall_score);
+
   return (
     <Link
       href={`/site/${_id}`}
@@ -69,14 +155,15 @@ export function SiteCard({
           <CardTitle>
             <h4>{site_name}</h4>
           </CardTitle>
-          <CardDescription>
+          <CardDescription className="flex flex-col gap-1">
+            <span>{getDomainLabel(normalized_base_url)}</span>
             <span>Analyzed {formatRelativeTime(last_analyzed)}</span>
           </CardDescription>
           <CardAction className="flex items-center gap-2">
             <span className="text-sm">Overall Score /100</span>
             <ScoreVisualizer
-              value={(overall_score ?? 0) / 100}
-              displayNumber={overall_score.toFixed(0)}
+              value={safeOverallScore / 100}
+              displayNumber={safeOverallScore.toFixed(0)}
               className="md:mr-1"
             />
           </CardAction>
@@ -85,23 +172,41 @@ export function SiteCard({
           <span className="-mt-2 text-center text-muted-foreground">
             Category Scores (/10)
           </span>
-          {category_scores.map((catg, index) => (
-            <div
-              key={index}
-              className="flex items-center justify-between gap-4"
-              aria-label={`${catg.category_name} score ${catg.category_score} out of 10`}
-            >
-              <p className="truncate text-base!">{catg.category_name}</p>
-              <ScoreVisualizer
-                value={(catg.category_score ?? 0) / 10}
-                size={32}
-                displayNumber={catg.category_score}
-              />
-            </div>
-          ))}
+          {category_scores.map((catg, index) => {
+            const safeCategoryScore = Number.isFinite(catg.category_score)
+              ? Math.min(10, Math.max(0, catg.category_score))
+              : 0;
+
+            return (
+              <div
+                key={index}
+                className="flex items-center justify-between gap-4"
+                aria-label={`${catg.category_name} score ${safeCategoryScore} out of 10`}
+              >
+                <p className="truncate text-base!">{catg.category_name}</p>
+                <ScoreVisualizer
+                  value={safeCategoryScore / 10}
+                  size={32}
+                  displayNumber={safeCategoryScore}
+                />
+              </div>
+            );
+          })}
         </CardContent>
         <CardFooter></CardFooter>
       </Card>
     </Link>
   );
+}
+
+function getSafeOverallScore(score: number) {
+  return Number.isFinite(score) ? Math.min(100, Math.max(0, score)) : 0;
+}
+
+function getDomainLabel(url: string) {
+  try {
+    return new URL(url).hostname.replace(/^www\./, "");
+  } catch {
+    return url;
+  }
 }


### PR DESCRIPTION
## Summary
- add a compact recent-sites table for large screens so results are easier to scan
- keep the existing card layout for smaller screens while adding domain labels to cards
- continue clamping invalid scores before rendering in both views

## Validation
- pnpm.cmd exec tsc --noEmit --pretty false
- pnpm.cmd build *(fails on existing main-branch issue: generateStaticParams for /site/[id] still requires NEXT_PUBLIC_CONVEX_URL when unset; tracked separately in PR #8)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced an XL-only tabular view for Recent Sites while keeping compact cards on smaller screens
  * Added a header subtitle showing the number of recent scans
  * Table rows link to site details, include a domain column with external links/outbound icon, show relative analyzed time, and improved overall score visualization

* **Bug Fixes**
  * Enhanced domain label parsing in site cards
  * Improved score display validation and bounds checking
<!-- end of auto-generated comment: release notes by coderabbit.ai -->