### PR TITLE
Guard site score rendering against incomplete analysis data

### DIFF
--- a/app/_components/recent-sites.tsx
+++ b/app/_components/recent-sites.tsx
@@ -11,7 +11,12 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import { RequireOnly, SiteDetails } from "@/convex/lib";
-import { cn, formatRelativeTime } from "@/lib/utils";
+import {
+  cn,
+  formatRelativeTime,
+  getCategoryScoreDisplay,
+  getOverallScoreDisplay,
+} from "@/lib/utils";
 import Link from "next/link";
 import ScoreVisualizer from "@/components/ui/score-visualizer";
 import { FunctionReturnType } from "convex/server";
@@ -54,6 +59,11 @@ export function SiteCard({
 }) {
   const { _id, site_name, overall_score, last_analyzed, category_scores } =
     site_details;
+  const safeOverallScore = getOverallScoreDisplay(overall_score);
+  const safeCategoryScores = (category_scores ?? []).map((category) => ({
+    ...category,
+    category_score: getCategoryScoreDisplay(category.category_score),
+  }));
   return (
     <Link
       href={`/site/${_id}`}
@@ -75,8 +85,8 @@ export function SiteCard({
           <CardAction className="flex items-center gap-2">
             <span className="text-sm">Overall Score /100</span>
             <ScoreVisualizer
-              value={(overall_score ?? 0) / 100}
-              displayNumber={overall_score.toFixed(0)}
+              value={safeOverallScore / 100}
+              displayNumber={safeOverallScore}
               className="md:mr-1"
             />
           </CardAction>
@@ -85,7 +95,7 @@ export function SiteCard({
           <span className="-mt-2 text-center text-muted-foreground">
             Category Scores (/10)
           </span>
-          {category_scores.map((catg, index) => (
+          {safeCategoryScores.map((catg, index) => (
             <div
               key={index}
               className="flex items-center justify-between gap-4"
@@ -93,7 +103,7 @@ export function SiteCard({
             >
               <p className="truncate text-base!">{catg.category_name}</p>
               <ScoreVisualizer
-                value={(catg.category_score ?? 0) / 10}
+                value={catg.category_score / 10}
                 size={32}
                 displayNumber={catg.category_score}
               />

--- a/app/site/[id]/page.tsx
+++ b/app/site/[id]/page.tsx
@@ -8,7 +8,12 @@ import {
 } from "@/components/ui/accordion";
 import { api } from "@/convex/_generated/api";
 import { Id } from "@/convex/_generated/dataModel";
-import { cn, formatRelativeTime } from "@/lib/utils";
+import {
+  cn,
+  formatRelativeTime,
+  getCategoryScoreDisplay,
+  getOverallScoreDisplay,
+} from "@/lib/utils";
 import { QuoteIcon } from "lucide-react";
 import Link from "next/link";
 import Loading from "../_components/loading";
@@ -46,6 +51,14 @@ export default async function SitePage({ params }: SitePageProps) {
     category_scores,
   } = full_site_details;
 
+  const safeOverallScore = getOverallScoreDisplay(overall_score);
+  const safeCategoryScores = (category_scores ?? []).map((category) => ({
+    ...category,
+    category_score: getCategoryScoreDisplay(category.category_score),
+    supporting_clauses: category.supporting_clauses ?? [],
+  }));
+  const safePolicyDocuments = policy_documents_urls ?? [];
+
   return (
     <>
       <section
@@ -54,9 +67,9 @@ export default async function SitePage({ params }: SitePageProps) {
         <div className="w-full md:col-span-2 flex flex-col gap-6">
           <div className="title flex flex-col items-center md:items-start gap-2">
             <ScoreVisualizer
-              value={overall_score / 100}
+              value={safeOverallScore / 100}
               size={128}
-              displayNumber={`${overall_score.toFixed(0)}`}
+              displayNumber={`${safeOverallScore}`}
               className="md:hidden mx-auto"
             />
             <h2 className="leading-16">{site_name}</h2>
@@ -77,9 +90,9 @@ export default async function SitePage({ params }: SitePageProps) {
               type="single"
               collapsible
               className="w-full"
-              defaultValue={`${category_scores[0].category_name}`}
+              defaultValue={safeCategoryScores[0]?.category_name}
             >
-              {category_scores.map((c) => (
+              {safeCategoryScores.map((c) => (
                 <AccordionItem
                   key={c.category_name}
                   value={c.category_name}
@@ -113,14 +126,20 @@ export default async function SitePage({ params }: SitePageProps) {
 
                   <AccordionContent>
                     <ul className="list-disc px-6 flex flex-col gap-2">
-                      {c.supporting_clauses.map((cl, index) => (
-                        <li
-                          key={index}
-                          className="text-sm! text-muted-foreground italic"
-                        >
-                          &quot;{cl}&quot;
+                      {c.supporting_clauses.length > 0 ? (
+                        c.supporting_clauses.map((cl, index) => (
+                          <li
+                            key={index}
+                            className="text-sm! text-muted-foreground italic"
+                          >
+                            &quot;{cl}&quot;
+                          </li>
+                        ))
+                      ) : (
+                        <li className="text-sm! text-muted-foreground italic">
+                          No supporting clauses were stored for this category.
                         </li>
-                      ))}
+                      )}
                     </ul>
                   </AccordionContent>
                 </AccordionItem>
@@ -131,9 +150,9 @@ export default async function SitePage({ params }: SitePageProps) {
 
         <div className="w-full h-fit md:col-span-1 flex flex-col items-center gap-6 sticky top-24">
           <ScoreVisualizer
-            value={overall_score / 100}
+            value={safeOverallScore / 100}
             size={256}
-            displayNumber={`${overall_score.toFixed(0)}`}
+            displayNumber={`${safeOverallScore}`}
             className="hidden md:flex"
           />
           <span className="text-sm -mt-3 hidden md:flex">Overall Score</span>
@@ -142,11 +161,17 @@ export default async function SitePage({ params }: SitePageProps) {
 
           <div className="w-full flex flex-col gap-3">
             <h5>Policy Documents</h5>
-            {policy_documents_urls.map((url) => (
-              <Link key={url} href={url} target="_blank">
-                {url}
-              </Link>
-            ))}
+            {safePolicyDocuments.length > 0 ? (
+              safePolicyDocuments.map((url) => (
+                <Link key={url} href={url} target="_blank">
+                  {url}
+                </Link>
+              ))
+            ) : (
+              <span className="text-sm text-muted-foreground">
+                No policy document links were stored for this analysis.
+              </span>
+            )}
           </div>
         </div>
       </section>

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -45,6 +45,27 @@ export function formatRelativeTime(dateString: string): string {
   }
 }
 
+export function clampScore(
+  value: number | null | undefined,
+  max: number,
+): number {
+  if (typeof value !== "number" || Number.isNaN(value)) {
+    return 0;
+  }
+
+  return Math.min(Math.max(value, 0), max);
+}
+
+export function getOverallScoreDisplay(value: number | null | undefined): number {
+  return Math.round(clampScore(value, 100));
+}
+
+export function getCategoryScoreDisplay(
+  value: number | null | undefined,
+): number {
+  return clampScore(value, 10);
+}
+
 export function slugify(text: string): string {
   return text
     .toLowerCase()


### PR DESCRIPTION
## Summary
- clamp recent-site and detail-page scores before rendering the visualizers
- avoid crashing the site detail view when category clauses or policy links are missing
- keep the UI informative with fallbacks for incomplete analysis payloads

## Validation
- pnpm.cmd exec tsc --noEmit --pretty false
- git diff --check


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced score normalization to properly handle missing or invalid score values across pages and components.
  * Improved user experience with fallback messages when supporting clauses or policy document links are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->