### PR TITLE
Fix invalid relative time copy

### DIFF
--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -6,43 +6,44 @@ export function cn(...inputs: ClassValue[]) {
 }
 
 export const isAnalysisStale = (lastAnalyzed: string): boolean => {
-  const twoWeeksInMs = 14 * 24 * 60 * 60 * 1000; // 2 weeks in milliseconds
-  const lastAnalyzedDate = new Date(lastAnalyzed);
-  const currentDate = new Date();
+  const twoWeeksInMs = 14 * 24 * 60 * 60 * 1000
+  const lastAnalyzedDate = new Date(lastAnalyzed)
 
-  return currentDate.getTime() - lastAnalyzedDate.getTime() > twoWeeksInMs;
-  // for testing - always return true;
-  // return true;
-};
+  if (Number.isNaN(lastAnalyzedDate.getTime())) {
+    return false
+  }
+
+  return Date.now() - lastAnalyzedDate.getTime() > twoWeeksInMs
+}
 
 export function formatRelativeTime(dateString: string): string {
-  try {
-    const date = new Date(dateString);
-    const formatter = new Intl.RelativeTimeFormat('en', { style: 'short' });
-    const diff = date.getTime() - Date.now();
+  const date = new Date(dateString)
 
-    const units = [
-      { unit: 'year', ms: 31536000000 },
-      { unit: 'month', ms: 2628000000 },
-      { unit: 'day', ms: 86400000 },
-      { unit: 'hour', ms: 3600000 },
-      { unit: 'minute', ms: 60000 },
-    ];
-
-    for (const { unit, ms } of units) {
-      if (Math.abs(diff) >= ms) {
-        return formatter.format(
-          Math.round(diff / ms),
-          unit as Intl.RelativeTimeFormatUnit
-        );
-      }
-    }
-
-    return 'Just now';
-  } catch (error) {
-    console.error('Invalid date format:', dateString, error);
-    return '';
+  if (Number.isNaN(date.getTime())) {
+    return ''
   }
+
+  const formatter = new Intl.RelativeTimeFormat('en', { style: 'short' })
+  const diff = date.getTime() - Date.now()
+
+  const units = [
+    { unit: 'year', ms: 31536000000 },
+    { unit: 'month', ms: 2628000000 },
+    { unit: 'day', ms: 86400000 },
+    { unit: 'hour', ms: 3600000 },
+    { unit: 'minute', ms: 60000 },
+  ]
+
+  for (const { unit, ms } of units) {
+    if (Math.abs(diff) >= ms) {
+      return formatter.format(
+        Math.round(diff / ms),
+        unit as Intl.RelativeTimeFormatUnit,
+      )
+    }
+  }
+
+  return 'Just now'
 }
 
 export function slugify(text: string): string {

--- a/tests/utils.spec.ts
+++ b/tests/utils.spec.ts
@@ -1,0 +1,14 @@
+import { describe, test } from 'node:test'
+import assert from 'node:assert/strict'
+
+import { formatRelativeTime, isAnalysisStale } from '@/lib/utils'
+
+describe('privacy-peek date helpers', () => {
+  test('returns an empty string for invalid relative-time inputs', () => {
+    assert.equal(formatRelativeTime('not-a-date'), '')
+  })
+
+  test('treats invalid timestamps as not stale', () => {
+    assert.equal(isAnalysisStale('not-a-date'), false)
+  })
+})


### PR DESCRIPTION
## Summary
- return an empty string for invalid relative-time inputs instead of falling through to misleading Just now
- treat invalid stale-analysis timestamps as non-stale instead of propagating NaN
- add focused date-helper regression coverage

## Validation
- bun test tests/utils.spec.ts
- pnpm.cmd exec tsc --noEmit --pretty false

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness of date formatting utilities to gracefully handle invalid date inputs without generating errors.
  * Enhanced validation in analysis staleness checks to properly manage edge cases with malformed timestamps.

* **Tests**
  * Added comprehensive test coverage for date utility functions, verifying proper behavior with invalid or malformed date inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->