### PR TITLE
Guard invalid relative-time labels

### DIFF
--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -16,33 +16,34 @@ export const isAnalysisStale = (lastAnalyzed: string): boolean => {
 };
 
 export function formatRelativeTime(dateString: string): string {
-  try {
-    const date = new Date(dateString);
-    const formatter = new Intl.RelativeTimeFormat('en', { style: 'short' });
-    const diff = date.getTime() - Date.now();
+  const date = new Date(dateString);
+  const timestamp = date.getTime();
 
-    const units = [
-      { unit: 'year', ms: 31536000000 },
-      { unit: 'month', ms: 2628000000 },
-      { unit: 'day', ms: 86400000 },
-      { unit: 'hour', ms: 3600000 },
-      { unit: 'minute', ms: 60000 },
-    ];
-
-    for (const { unit, ms } of units) {
-      if (Math.abs(diff) >= ms) {
-        return formatter.format(
-          Math.round(diff / ms),
-          unit as Intl.RelativeTimeFormatUnit
-        );
-      }
-    }
-
-    return 'Just now';
-  } catch (error) {
-    console.error('Invalid date format:', dateString, error);
-    return '';
+  if (Number.isNaN(timestamp)) {
+    return "";
   }
+
+  const formatter = new Intl.RelativeTimeFormat("en", { style: "short" });
+  const diff = timestamp - Date.now();
+
+  const units = [
+    { unit: "year", ms: 31536000000 },
+    { unit: "month", ms: 2628000000 },
+    { unit: "day", ms: 86400000 },
+    { unit: "hour", ms: 3600000 },
+    { unit: "minute", ms: 60000 },
+  ];
+
+  for (const { unit, ms } of units) {
+    if (Math.abs(diff) >= ms) {
+      return formatter.format(
+        Math.round(diff / ms),
+        unit as Intl.RelativeTimeFormatUnit,
+      );
+    }
+  }
+
+  return "Just now";
 }
 
 export function slugify(text: string): string {

--- a/tests/utils.spec.mjs
+++ b/tests/utils.spec.mjs
@@ -1,0 +1,14 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { formatRelativeTime } from "../lib/utils.ts";
+
+test("formatRelativeTime returns an empty label for invalid dates", () => {
+  assert.equal(formatRelativeTime("not-a-date"), "");
+});
+
+test("formatRelativeTime still renders a relative label for valid past dates", () => {
+  const ninetyMinutesAgo = new Date(Date.now() - 90 * 60 * 1000).toISOString();
+
+  assert.equal(formatRelativeTime(ninetyMinutesAgo), "2 hr. ago");
+});


### PR DESCRIPTION
## Summary
- stop invalid timestamps from rendering misleading \Just now\ copy
- add focused coverage for invalid and valid relative-time labels

## Testing
- node --experimental-strip-types --test tests/utils.spec.mjs
- pnpm.cmd exec tsc --noEmit --pretty false

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved relative time formatting to gracefully handle invalid dates without error logging.

* **Tests**
  * Added test coverage for relative time formatting functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->