### PR TITLE
fix: stabilize sidebar loading skeleton widths

### DIFF
--- a/components/ui/sidebar.tsx
+++ b/components/ui/sidebar.tsx
@@ -6,6 +6,7 @@ import { cva, VariantProps } from "class-variance-authority"
 import { PanelLeftIcon } from "lucide-react"
 
 import { useIsMobile } from "@/hooks/use-mobile"
+import { getSidebarSkeletonWidth } from "@/lib/sidebar-skeleton"
 import { cn } from "@/lib/utils"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
@@ -606,10 +607,8 @@ function SidebarMenuSkeleton({
 }: React.ComponentProps<"div"> & {
   showIcon?: boolean
 }) {
-  // Random width between 50 to 90%.
-  const width = React.useMemo(() => {
-    return `${Math.floor(Math.random() * 40) + 50}%`
-  }, [])
+  const skeletonId = React.useId()
+  const width = React.useMemo(() => getSidebarSkeletonWidth(skeletonId), [skeletonId])
 
   return (
     <div

--- a/lib/sidebar-skeleton.ts
+++ b/lib/sidebar-skeleton.ts
@@ -1,0 +1,13 @@
+const sidebar_skeleton_widths = ['52%', '61%', '68%', '76%', '84%'] as const
+
+export function getSidebarSkeletonWidth(seed: string): (typeof sidebar_skeleton_widths)[number] {
+  let hash = 0
+
+  for (const character of seed) {
+    hash = (hash * 31 + character.charCodeAt(0)) >>> 0
+  }
+
+  return sidebar_skeleton_widths[hash % sidebar_skeleton_widths.length]
+}
+
+export { sidebar_skeleton_widths }

--- a/tests/sidebar-skeleton.spec.ts
+++ b/tests/sidebar-skeleton.spec.ts
@@ -1,0 +1,23 @@
+import { describe, test } from 'node:test'
+import assert from 'node:assert/strict'
+
+import { getSidebarSkeletonWidth, sidebar_skeleton_widths } from '../lib/sidebar-skeleton.ts'
+
+describe('getSidebarSkeletonWidth', () => {
+  test('returns deterministic widths for the same seed', () => {
+    assert.equal(getSidebarSkeletonWidth(':r0:'), getSidebarSkeletonWidth(':r0:'))
+    assert.equal(getSidebarSkeletonWidth(':r1:'), getSidebarSkeletonWidth(':r1:'))
+  })
+
+  test('only returns supported width tokens', () => {
+    const seen = new Set<string>()
+
+    for (const seed of [':r0:', ':r1:', ':r2:', ':r3:', ':r4:', ':r5:', ':r6:']) {
+      const width = getSidebarSkeletonWidth(seed)
+      assert.ok(sidebar_skeleton_widths.includes(width))
+      seen.add(width)
+    }
+
+    assert.ok(seen.size >= 3)
+  })
+})


### PR DESCRIPTION
## Summary
- replace random sidebar skeleton widths with deterministic seeded widths
- keep placeholder variation without risking SSR/hydration drift
- add a focused regression test for the width helper

## Testing
- node --experimental-strip-types --test tests/sidebar-skeleton.spec.ts
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Sidebar skeleton loading placeholders now consistently display with predetermined widths for more predictable visual behavior.

* **Tests**
  * New test suite validates that sidebar skeleton widths are deterministic and include appropriate variety across different instances.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->