### PR TITLE
[codex] Fix analysis robustness and job status handling

### DIFF
--- a/app/_components/SearchComponent.tsx
+++ b/app/_components/SearchComponent.tsx
@@ -35,7 +35,7 @@ import {
   Settings2,
 } from "lucide-react";
 import Link from "next/link";
-import { startTransition, useActionState, useState } from "react";
+import { startTransition, useActionState, useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
 import z from "zod";
 import { ResultItem } from "@/convex/actions";
@@ -69,6 +69,10 @@ export default function SearchComponent() {
   const [displayedResults, setDisplayedResults] = useState<ResultItem[] | null>(
     null,
   );
+  const ongoingJob = useQuery(
+    api.analysisJobs.getJob,
+    jobId ? { job_id: jobId } : "skip",
+  );
 
   const [state, submit, isPending] = useActionState(
     async (_prev: ActionState, value: SearchValue): Promise<ActionState> => {
@@ -100,14 +104,23 @@ export default function SearchComponent() {
           console.log("Failed to retrieve site analysis.");
           return { ok: false, message: "Failed to retrieve site analysis!" };
         }
-      } finally {
-        setTimeout(() => {
-          setJobId(null);
-        }, 3000);
       }
     },
     initialState,
   );
+
+  useEffect(() => {
+    if (!jobId) return;
+
+    const status = ongoingJob?.status;
+    if (status !== "complete" && status !== "error") return;
+
+    const timeout = window.setTimeout(() => {
+      setJobId(null);
+    }, 3000);
+
+    return () => window.clearTimeout(timeout);
+  }, [jobId, ongoingJob?.status]);
 
   return (
     <Form {...form}>

--- a/app/site/[id]/page.tsx
+++ b/app/site/[id]/page.tsx
@@ -45,6 +45,7 @@ export default async function SitePage({ params }: SitePageProps) {
     overall_score,
     category_scores,
   } = full_site_details;
+  const defaultCategory = category_scores[0]?.category_name;
 
   return (
     <>
@@ -77,7 +78,7 @@ export default async function SitePage({ params }: SitePageProps) {
               type="single"
               collapsible
               className="w-full"
-              defaultValue={`${category_scores[0].category_name}`}
+              defaultValue={defaultCategory}
             >
               {category_scores.map((c) => (
                 <AccordionItem

--- a/convex/actions.ts
+++ b/convex/actions.ts
@@ -274,8 +274,12 @@ const getCategoryScores = async ({
     }
   });
 
-  const scores = await Promise.all(promises);
-  if (!scores) throw new Error("Something went wrong.");
+  const scores = (await Promise.all(promises)).filter(
+    (score): score is NonNullable<typeof score> => score !== undefined,
+  );
+  if (scores.length === 0) {
+    throw new Error("No category scores could be generated.");
+  }
 
   return scores as Array<{
     category_name: CategoryName;
@@ -290,7 +294,13 @@ const getOverallScore = async ({
 }: {
   categoryScores: Awaited<ReturnType<typeof getCategoryScores>>;
 }) => {
-  const weightsTotal = categoryWeights.reduce((sum, w) => sum + w.weight, 0);
+  const appliedWeights = categoryWeights.filter((weight) =>
+    categoryScores.some((score) => score.category_name === weight.category),
+  );
+  const weightsTotal = appliedWeights.reduce((sum, w) => sum + w.weight, 0);
+  if (weightsTotal === 0) {
+    throw new Error("No category weights available for computed scores.");
+  }
 
   const weight_x_score_sum = categoryScores
     .map(

--- a/convex/analysisJobs.ts
+++ b/convex/analysisJobs.ts
@@ -25,6 +25,9 @@ export const getJob = query({
 export const updateJob = internalMutation({
   args: { job_id: v.id('analysisJobs'), status: AnalysisStatusValidator },
   handler: async (ctx, { job_id, status }) => {
-    await ctx.db.patch(job_id, { status });
+    await ctx.db.patch(job_id, {
+      status,
+      updated_at: new Date().toISOString(),
+    });
   },
 });

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "dev": "next dev --turbopack",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "eslint ."
   },
   "dependencies": {
     "@ai-sdk/groq": "3.0.0-beta.47",


### PR DESCRIPTION
## What changed
- replaced the removed `next lint` script with `eslint .`
- updated analysis job status mutations to refresh `updated_at`
- filtered out empty category-score results before computing the overall score
- guarded the site detail accordion against missing category scores
- kept the search progress indicator visible until the job actually finishes or errors

## Why
A few small bugs were stacking together:
- the repo’s default lint command no longer works on Next 16
- job status records looked stale because the timestamp never changed after creation
- partial model output could leave `undefined` entries in `categoryScores`, which could break score calculation and the site detail page
- the search UI could hide progress after 3 seconds even while analysis was still running

## Impact
These fixes make the analysis flow more resilient, keep status tracking honest, and prevent the detail page from assuming data that may not exist yet.

## Validation
- reviewed the edited code paths and resulting diff
- confirmed the updated `package.json` is valid JSON
- full dependency-based checks were not run in this environment because package installation is blocked here

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling in analysis score calculations when certain categories are incomplete or unavailable during processing.
  * Enhanced weight calculation logic to correctly handle scenarios with partial category datasets and missing rubric information.
  * Refined cleanup behavior for analysis jobs to trigger appropriately based on job completion or error status.

* **Chores**
  * Updated linting command configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->