### PR TITLE
fix: edge case handling across search, compare, scores, and accessibility

### DIFF
--- a/app/_components/SearchComponent.tsx
+++ b/app/_components/SearchComponent.tsx
@@ -293,6 +293,14 @@ function JobStatus({ job_id }: { job_id: Id<"analysisJobs"> }) {
   }
 
   const display = STATUS_DISPLAY[status];
+  if (!display) {
+    return (
+      <div className="w-full flex items-center justify-center gap-2 py-1">
+        <Clock className="size-3 text-muted-foreground" />
+        <span className="text-sm text-muted-foreground">Processing...</span>
+      </div>
+    );
+  }
 
   return (
     <>

--- a/app/_components/SearchComponent.tsx
+++ b/app/_components/SearchComponent.tsx
@@ -33,6 +33,7 @@ import {
   Globe,
   History,
   Settings2,
+  X,
 } from "lucide-react";
 import Link from "next/link";
 import { startTransition, useActionState, useEffect, useState } from "react";
@@ -171,6 +172,7 @@ export default function SearchComponent() {
                         shouldTouch: true,
                       });
                       setDisplayedResults(null);
+                      setJobId(null);
                     }}
                     className="absolute right-3 top-1/2 -translate-y-1/2 size-6 rounded-full flex items-center justify-center text-muted-foreground hover:text-foreground hover:bg-accent transition-colors"
                     aria-label="Clear search"

--- a/app/compare/page.tsx
+++ b/app/compare/page.tsx
@@ -46,7 +46,7 @@ import Link from "next/link";
 import type { Doc } from "@/convex/_generated/dataModel";
 
 type SiteBrief = NonNullable<
-  ReturnType<typeof api.sites.getSitesBrief._returnType>
+  typeof api.sites.getSitesBrief._returnType
 >[number];
 
 export default function ComparePage() {
@@ -197,7 +197,7 @@ function ComparisonGrid({
   sites,
   onRemove,
 }: {
-  sites: NonNullable<ReturnType<typeof api.sites.getSitesByIds._returnType>>;
+  sites: NonNullable<typeof api.sites.getSitesByIds._returnType>;
   onRemove: (id: Id<"sites">) => void;
 }) {
   const cols = Math.min(sites.length, 4);

--- a/app/compare/page.tsx
+++ b/app/compare/page.tsx
@@ -103,11 +103,11 @@ export default function ComparePage() {
               role="combobox"
               aria-expanded={open}
               className="w-full max-w-md justify-between"
-              disabled={!allSites}
+              disabled={!allSites || selectedIds.length >= 4}
             >
               <span className="flex items-center gap-2">
                 <Plus className="size-4" />
-                Add site to compare
+                {selectedIds.length >= 4 ? "Maximum 4 sites" : "Add site to compare"}
               </span>
               <ChevronsUpDown className="ml-2 size-4 shrink-0 opacity-50" />
             </Button>

--- a/app/error.tsx
+++ b/app/error.tsx
@@ -1,0 +1,24 @@
+'use client';
+
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <section className="min-h-[60dvh] flex flex-col items-center justify-center gap-6 px-4 text-center" role="alert">
+      <h2>Something went wrong</h2>
+      <p className="text-muted-foreground max-w-md">
+        {error.message || 'An unexpected error occurred. Please try again.'}
+      </p>
+      <button
+        onClick={() => reset()}
+        className="inline-flex items-center justify-center gap-2 rounded-xl border px-4 py-2.5 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground"
+      >
+        Try again
+      </button>
+    </section>
+  );
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,6 +4,7 @@ import './globals.css';
 import { ConvexClientProvider } from './ConvexClientProvider';
 import { ThemeProvider } from '@/components/theme-provider';
 import { NavBar } from '@/components/global/Navbar';
+import { ErrorBoundary } from '@/components/ErrorBoundary';
 
 export const metadata: Metadata = {
   metadataBase: new URL('https://privacy-peek.vercel.app'),
@@ -44,7 +45,9 @@ export default function RootLayout({
           disableTransitionOnChange>
           <ConvexClientProvider>
             <NavBar />
-            {children}
+            <ErrorBoundary>
+              {children}
+            </ErrorBoundary>
           </ConvexClientProvider>
         </ThemeProvider>
       </body>

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,0 +1,11 @@
+import Link from "next/link";
+
+export default function NotFound() {
+  return (
+    <section className="min-h-[90vh] flex flex-col items-center justify-center gap-12">
+      <h1>404</h1>
+      <h3>This page could not be found.</h3>
+      <Link href="/">Click here to go back to the home page.</Link>
+    </section>
+  );
+}

--- a/app/site/[id]/page.tsx
+++ b/app/site/[id]/page.tsx
@@ -75,10 +75,14 @@ export default async function SitePage({ params }: SitePageProps) {
               displayNumber={`${safeOverallScore}`}
               className="md:hidden mx-auto"
             />
-            <h2 className="leading-16">{site_name}</h2>
-            <Link href={normalized_base_url} target="_blank">
-              {normalized_base_url}
-            </Link>
+            <h2 className="leading-16">{site_name || "Unnamed Site"}</h2>
+            {normalized_base_url ? (
+              <Link href={normalized_base_url} target="_blank">
+                {normalized_base_url}
+              </Link>
+            ) : (
+              <span className="text-muted-foreground">No URL available</span>
+            )}
             <span className="">
               Last analysed {formatRelativeTime(last_analyzed)}.
             </span>

--- a/components/ErrorBoundary.tsx
+++ b/components/ErrorBoundary.tsx
@@ -1,0 +1,56 @@
+'use client';
+
+import React from 'react';
+
+interface ErrorBoundaryProps {
+  children: React.ReactNode;
+  fallback?: React.ReactNode;
+}
+
+interface ErrorBoundaryState {
+  hasError: boolean;
+  error: Error | null;
+}
+
+export class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  constructor(props: ErrorBoundaryProps) {
+    super(props);
+    this.state = { hasError: false, error: null };
+  }
+
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error: Error, info: React.ErrorInfo) {
+    console.error('ErrorBoundary caught:', error, info);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      if (this.props.fallback) {
+        return this.props.fallback;
+      }
+
+      return (
+        <section className="min-h-[60dvh] flex flex-col items-center justify-center gap-6 px-4 text-center" role="alert">
+          <h2>Something went wrong</h2>
+          <p className="text-muted-foreground max-w-md">
+            {this.state.error?.message || 'An unexpected error occurred while rendering this section.'}
+          </p>
+          <button
+            onClick={() => {
+              this.setState({ hasError: false, error: null });
+              window.location.reload();
+            }}
+            className="inline-flex items-center justify-center gap-2 rounded-xl border px-4 py-2.5 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground"
+          >
+            Reload page
+          </button>
+        </section>
+      );
+    }
+
+    return this.props.children;
+  }
+}

--- a/components/ui/score-visualizer.tsx
+++ b/components/ui/score-visualizer.tsx
@@ -38,7 +38,9 @@ const ScoreVisualizer: React.FC<ScoreVisualizerProps> = ({
   return (
     <div
       className={cn('relative inline-block', className)}
-      style={{ width: size, height: size }}>
+      style={{ width: size, height: size }}
+      role="img"
+      aria-label={`Score: ${displayNumber ? displayNumber : Math.round(score * 100) + '%'} out of 100`}>
       <svg
         width={size}
         height={size}

--- a/convex/actions.ts
+++ b/convex/actions.ts
@@ -250,7 +250,7 @@ const getCategoryScores = async ({
   }
 
   const promises = categoriesClauses.map(async (category) => {
-    const filteredClauses = category.clauses.filter((c) => c.relevance >= 0.3);
+    const filteredClauses = (category.clauses ?? []).filter((c) => c.relevance >= 0.3);
 
     if (filteredClauses.length === 0) {
       console.warn(
@@ -274,7 +274,7 @@ const getCategoryScores = async ({
       rubric: categoryRubric,
     });
 
-    if (!category_score || !reasoning) {
+    if (category_score == null || !reasoning) {
       throw new Error(
         `An unknown error occured scoring ${category.category_name}`,
       );

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -104,6 +104,6 @@ export function slugify(text: string): string {
     .trim()
     .replace(/\s+/g, '-')
     .replace(/&/g, '-and-')
-    .replace(/[^w\-]+/g, '')
+    .replace(/[^\w\-]+/g, '')
     .replace(/\-\-+/g, '-');
 }


### PR DESCRIPTION
## Summary

Two-part bugfix and edge case pass.

### Part 1 (previous commits)
- Fix slugify regex — missing backslash in character class matched literal 'w' instead of \w
- Fix JobStatus crash on unknown status values — added safe fallback component
- Fix falsy check rejecting valid 0 scores — changed `!score` to `== null`
- Fix missing null-guard on category.clauses — added optional chaining with ?? []

### Part 2 (this commit)
- **Critical bugfix** — `X` icon used in SearchComponent's clear button but never imported (would cause runtime error on the clear button path)
- **Stale jobId cleanup** — Clearing search now also clears `jobId` to stop orphaned job status queries
- **Max 4 sites enforced** — Compare Add button disables at 4 with "Maximum 4 sites" text
- **Error resilience** — React ErrorBoundary wraps app children, app-level error.tsx and not-found.tsx added
- **Accessibility** — ScoreVisualizer gets `role='img'` and `aria-label` with score text for screen readers
- **Empty/null fallbacks** — Site detail page handles missing `site_name` ("Unnamed Site") and empty `normalized_base_url` (no broken links)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved job status handling with a centered “Processing...” indicator when status details are unavailable.
  * Better category scoring robustness (including correct handling of zero scores).
  * Fixed slug generation to strip the intended characters.
* **New Features / UI Updates**
  * Clearing search now also hides any active job status.
  * Compare selection is capped at 4 sites, with the action disabled and the label updated.
  * Site pages now show sensible fallbacks when name or URL data is missing.
* **Reliability & Error Handling**
  * Added an error boundary and a dedicated error screen (“Try again”), plus improved the 404 page.
* **Accessibility**
  * Enhanced the score visualizer with improved screen-reader labeling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->