### PR TITLE
fix: query ordering, URL consistency, and type accuracy

### DIFF
--- a/app/site/[id]/page.tsx
+++ b/app/site/[id]/page.tsx
@@ -236,7 +236,7 @@ export async function generateMetadata({
     return {
       title: "Privacy Peek",
       description: "Full privacy policy analysis.",
-      metadataBase: new URL("https://privacypeek.vercel.app"),
+      metadataBase: new URL("https://privacy-peek.vercel.app"),
     };
   }
 
@@ -251,7 +251,7 @@ export async function generateMetadata({
       : "Full privacy policy analysis.",
     creator: "Roci",
     keywords: ["privacy peek", "privacy", "policy analysis", "online privacy"],
-    metadataBase: new URL("https://privacypeek.vercel.app"),
+    metadataBase: new URL("https://privacy-peek.vercel.app"),
     authors: [
       { name: "Roci", url: "https://jomo.aqutte.co.ke" },
       { name: "Privacy Peek" },

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -6,7 +6,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   if (!process.env.NEXT_PUBLIC_CONVEX_URL) {
     return [
       {
-        url: "https://privacypeek.vercel.app",
+        url: "https://privacy-peek.vercel.app",
         lastModified: new Date(),
         changeFrequency: "daily",
         priority: 1,
@@ -27,7 +27,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
 
   return [
     {
-      url: "https://privacypeek.vercel.app",
+      url: "https://privacy-peek.vercel.app",
       lastModified: new Date(),
       changeFrequency: 'daily',
       priority: 1,

--- a/convex/actions.ts
+++ b/convex/actions.ts
@@ -154,7 +154,7 @@ export const reanalyzeSite = action({
         site_id,
         overall_score: overallScore.overall_score,
         reasoning: overallScore.reasoning || "",
-        category_scores: categoryScores as any,
+        category_scores: categoryScores,
         last_analyzed: new Date().toISOString(),
       });
 

--- a/convex/lib.ts
+++ b/convex/lib.ts
@@ -38,6 +38,7 @@ export interface SiteDetails {
     category_name: CategoryName;
     category_score: number;
     reasoning: string;
+    supporting_clauses: string[];
   }>;
 }
 

--- a/convex/sites.ts
+++ b/convex/sites.ts
@@ -152,6 +152,7 @@ export const getSitesBrief = query({
   handler: async (ctx, { limit }) => {
     const results = await ctx.db
       .query("sites")
+      .withIndex("by_last_analyzed")
       .order("desc")
       .take(limit ?? 100);
     return results.map((s) => ({


### PR DESCRIPTION
## Summary

Four codebase fixes caught during audit:

- **`getSitesBrief` query order fix** — Was using default `_creationTime` ordering instead of `by_last_analyzed` index. This could silently drop recently-analyzed sites from the directory if there were 200+ sites, since only the newest-by-creation were fetched.
- **`SiteDetails` interface updated** — Added missing `supporting_clauses` to `category_scores` field to match the actual Convex schema and generated types.
- **Removed unnecessary `as any` cast** — `getCategoryScores` already returns the correct shape matching `updateSiteAnalysis` args. The cast was masking type safety.
- **Standardized `metadataBase` URLs** — Sitemap and `generateMetadata` were using `privacypeek.vercel.app` (no hyphen) while the layout uses `privacy-peek.vercel.app` (with hyphen, matching package name). All now point to the canonical domain.

## Test Plan
- [x] `npx next build` passes clean (Compiled successfully in ~23s)
- [x] TypeScript check passes
- [ ] Vercel deployment (awaiting)