### PR TITLE
feat: add CSV export and dashboard stats to sites directory

### DIFF
--- a/app/sites/page.tsx
+++ b/app/sites/page.tsx
@@ -8,6 +8,12 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Badge } from "@/components/ui/badge";
 import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import {
   Table,
   TableBody,
   TableCell,
@@ -46,6 +52,9 @@ import {
   GitCompareArrowsIcon,
   ListIcon,
   ExternalLink,
+  Download,
+  AlertTriangle,
+  ChartNoAxesColumnIncreasing,
 } from "lucide-react";
 import Link from "next/link";
 
@@ -56,6 +65,8 @@ const ITEMS_PER_PAGE = 20;
 
 export default function SitesDirectory() {
   const allSites = useQuery(api.sites.getSitesBrief, { limit: 200 });
+  const exportData = useQuery(api.sites.getAllSitesExportData);
+  const stats = useQuery(api.sites.getSitesStats);
 
   const [searchQuery, setSearchQuery] = useState("");
   const [sortField, setSortField] = useState<SortField>("last_analyzed");
@@ -116,6 +127,66 @@ export default function SitesDirectory() {
     ) : (
       <ArrowDown className="size-3" />
     );
+  };
+
+  const downloadCSV = () => {
+    if (!exportData || exportData.length === 0) return;
+
+    const headers = [
+      "Site Name",
+      "Domain",
+      "Overall Score",
+      "Reasoning",
+      "Last Analyzed",
+      "Data Collection",
+      "Data Sharing",
+      "Data Retention and Security",
+      "User Rights and Controls",
+      "Transparency and Clarity",
+      "Policy Documents",
+    ];
+
+    const rows = exportData.map((site) => {
+      const domain = (() => {
+        try {
+          return new URL(site.normalized_base_url).hostname.replace(/^www\./, "");
+        } catch {
+          return site.normalized_base_url;
+        }
+      })();
+
+      const catScores: Record<string, number | string> = {};
+      for (const c of site.category_scores ?? []) {
+        catScores[c.category_name] = c.category_score;
+      }
+
+      return [
+        site.site_name,
+        domain,
+        site.overall_score,
+        `"${(site.reasoning ?? "").replace(/"/g, '""')}"`,
+        site.last_analyzed,
+        catScores["Data Collection"] ?? "",
+        catScores["Data Sharing"] ?? "",
+        catScores["Data Retention and Security"] ?? "",
+        catScores["User Rights and Controls"] ?? "",
+        catScores["Transparency and Clarity"] ?? "",
+        `"${(site.policy_documents_urls ?? []).join("; ")}"`,
+      ];
+    });
+
+    const csvContent = [
+      headers.join(","),
+      ...rows.map((row) => row.join(",")),
+    ].join("\n");
+
+    const blob = new Blob([csvContent], { type: "text/csv;charset=utf-8;" });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement("a");
+    link.href = url;
+    link.download = `privacy-peek-sites-${new Date().toISOString().split("T")[0]}.csv`;
+    link.click();
+    URL.revokeObjectURL(url);
   };
 
   const renderPageNumbers = () => {
@@ -201,6 +272,48 @@ export default function SitesDirectory() {
             Browse, search, and sort through all analyzed sites.
           </p>
         </div>
+
+        {/* Stats summary */}
+        {stats && stats.total > 0 && (
+          <div className="flex flex-wrap items-center gap-4 rounded-2xl border bg-card px-5 py-3">
+            <div className="flex items-center gap-3">
+              <ChartNoAxesColumnIncreasing className="size-4 text-muted-foreground" />
+              <div className="flex flex-wrap items-baseline gap-x-3 gap-y-1 text-sm">
+                <span className="text-muted-foreground">
+                  <strong className="text-foreground font-semibold">{stats.total}</strong> sites
+                </span>
+                <span className="text-muted-foreground">
+                  Avg: <strong className="text-foreground font-semibold">{stats.avgScore.toFixed(1)}</strong>/100
+                </span>
+                {stats.staleCount > 0 && (
+                  <span className="flex items-center gap-1 text-amber-600 dark:text-amber-400">
+                    <AlertTriangle className="size-3.5" />
+                    <strong className="font-semibold">{stats.staleCount}</strong> stale
+                  </span>
+                )}
+              </div>
+            </div>
+            <TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={downloadCSV}
+                    disabled={!exportData || exportData.length === 0}
+                    className="ml-auto gap-1.5 shrink-0"
+                  >
+                    <Download className="size-3.5" />
+                    <span className="hidden sm:inline">Export CSV</span>
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>
+                  Download all analysis data as a CSV file
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
+          </div>
+        )}
 
         {/* Search */}
         <div className="relative w-full max-w-md">

--- a/convex/sites.ts
+++ b/convex/sites.ts
@@ -172,6 +172,45 @@ export const getFullSiteDetail = internalQuery({
   },
 });
 
+export const getAllSitesExportData = query({
+  handler: async (ctx) => {
+    const allSites = await ctx.db.query("sites").collect();
+    return allSites.map((s) => ({
+      _id: s._id,
+      site_name: s.site_name,
+      normalized_base_url: s.normalized_base_url,
+      overall_score: s.overall_score,
+      reasoning: s.reasoning,
+      last_analyzed: s.last_analyzed,
+      category_scores: s.category_scores,
+      policy_documents_urls: s.policy_documents_urls,
+    }));
+  },
+});
+
+export const getSitesStats = query({
+  handler: async (ctx) => {
+    const allSites = await ctx.db.query("sites").collect();
+    const total = allSites.length;
+    if (total === 0) {
+      return { total: 0, avgScore: 0, staleCount: 0 };
+    }
+
+    const sumScores = allSites.reduce((acc, s) => acc + s.overall_score, 0);
+    const avgScore = Math.round((sumScores / total) * 100) / 100;
+
+    // Check staleness client-side by returning last_analyzed dates
+    const now = Date.now();
+    const STALE_MS = 14 * 24 * 60 * 60 * 1000;
+    const staleCount = allSites.filter((s) => {
+      const analyzed = new Date(s.last_analyzed).getTime();
+      return !Number.isNaN(analyzed) && now - analyzed >= STALE_MS;
+    }).length;
+
+    return { total, avgScore, staleCount };
+  },
+});
+
 export const updateSiteAnalysis = internalMutation({
   args: {
     site_id: v.id("sites"),


### PR DESCRIPTION
## Summary
- Adds a stats summary banner at the top of the sites directory showing total count, average score, and stale analysis count
- Adds a CSV export button that downloads all analyzed sites with full category scores and policy document URLs
- Adds two new Convex queries: `getAllSitesExportData` and `getSitesStats`

## Details
The stats banner gives users a quick overview of their privacy analysis collection at a glance — how many sites have been analyzed, the average privacy score, and how many are stale (over 14 days old).

The CSV export includes site name, domain, overall score, reasoning text, last analyzed date, per-category scores across all 5 categories, and a list of analyzed policy documents. Perfect for offline analysis, reports, or sharing with teams.

## Test Plan
- [x] Build passes locally (`npx next build`)
- [ ] Stats banner renders on /sites
- [ ] CSV downloads correctly with full data

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a stats summary card showing total sites, average score, and a stale-site count when available.
  * Added CSV export for site data, including scores and related details.
  * Added a tooltip on the export action and disabled it when no exportable data is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->