### PR TITLE
fix: edge case handling — CSV export, ID validation, loading states, score display

### DIFF
--- a/app/_components/SearchComponent.tsx
+++ b/app/_components/SearchComponent.tsx
@@ -17,7 +17,7 @@ import {
 } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
 import { api } from "@/convex/_generated/api";
-import { cn, safeSiteName } from "@/lib/utils";
+import { cn, getOverallScoreDisplay, safeSiteName } from "@/lib/utils";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useAction, useMutation, useQuery } from "convex/react";
 import {
@@ -379,6 +379,7 @@ function JobStatus({ job_id }: { job_id: Id<"analysisJobs"> }) {
 
 export function ResultCard({ site }: { site: ResultItem }) {
   const { site_name, overall_score, reasoning } = site;
+  const safeScore = getOverallScoreDisplay(overall_score);
   return (
     <Link
       href={`/site/${site._id}`}
@@ -404,8 +405,8 @@ export function ResultCard({ site }: { site: ResultItem }) {
           <CardAction className="flex items-center gap-2">
             <span className="text-sm">Overall Score /100</span>
             <ScoreVisualizer
-              value={(overall_score ?? 0) / 100}
-              displayNumber={Math.round(overall_score)}
+              value={(safeScore) / 100}
+              displayNumber={safeScore}
               className="md:mr-1"
               size={48}
             />

--- a/app/compare/page.tsx
+++ b/app/compare/page.tsx
@@ -214,6 +214,23 @@ function ComparePageContent() {
           </motion.div>
         )}
 
+        {/* Loading state when sites are selected but data hasn't arrived yet */}
+        {!selectedSites && selectedIds.length > 0 && (
+          <div className="flex-1 flex items-center justify-center">
+            <p className="text-muted-foreground animate-pulse">
+              Loading selected sites...
+            </p>
+          </div>
+        )}
+
+        {!selectedSites && selectedIds.length === 0 && (
+          <div className="flex-1 flex items-center justify-center">
+            <p className="text-muted-foreground animate-pulse">
+              Loading available sites...
+            </p>
+          </div>
+        )}
+
         {selectedSites && selectedSites.length === 1 && (
           <motion.div
             key="single"
@@ -241,14 +258,6 @@ function ComparePageContent() {
           >
             <ComparisonGrid sites={selectedSites} onRemove={removeSite} />
           </motion.div>
-        )}
-
-        {!selectedSites && (
-          <div className="flex-1 flex items-center justify-center">
-            <p className="text-muted-foreground animate-pulse">
-              Loading sites...
-            </p>
-          </div>
         )}
       </section>
     </motion.div>

--- a/app/site/[id]/page.tsx
+++ b/app/site/[id]/page.tsx
@@ -36,6 +36,15 @@ export default async function SitePage({ params }: SitePageProps) {
 
   const { id } = await params;
 
+  // Validate the site ID format before querying — catches malformed/injected IDs early
+  const isLikelyValidId = (str: string): boolean => {
+    // Convex IDs are 28-character base64url strings
+    return /^[a-zA-Z0-9_-]{28}$/.test(str);
+  };
+  if (!isLikelyValidId(id)) {
+    return <NotFound />;
+  }
+
   const full_site_details = await fetchQuery(api.sites.getFullSiteDetails, {
     site_id: id,
   });

--- a/app/sites/page.tsx
+++ b/app/sites/page.tsx
@@ -132,6 +132,16 @@ export default function SitesDirectory() {
     );
   };
 
+  /** Escape a single CSV field — handles commas, quotes, and newlines */
+  const csvField = (value: unknown): string => {
+    const str = String(value ?? "");
+    // RFC 4180: wrap in quotes if contains comma, quote, or newline
+    if (/[",\n\r]/.test(str)) {
+      return `"${str.replace(/"/g, '""')}"`;
+    }
+    return str;
+  };
+
   const downloadCSV = () => {
     if (!exportData || exportData.length === 0) return;
 
@@ -164,17 +174,17 @@ export default function SitesDirectory() {
       }
 
       return [
-        site.site_name,
-        domain,
-        site.overall_score,
-        `"${(site.reasoning ?? "").replace(/"/g, '""')}"`,
-        site.last_analyzed,
-        catScores["Data Collection"] ?? "",
-        catScores["Data Sharing"] ?? "",
-        catScores["Data Retention and Security"] ?? "",
-        catScores["User Rights and Controls"] ?? "",
-        catScores["Transparency and Clarity"] ?? "",
-        `"${(site.policy_documents_urls ?? []).join("; ")}"`,
+        csvField(site.site_name),
+        csvField(domain),
+        csvField(site.overall_score),
+        csvField(site.reasoning ?? ""),
+        csvField(site.last_analyzed),
+        csvField(catScores["Data Collection"] ?? ""),
+        csvField(catScores["Data Sharing"] ?? ""),
+        csvField(catScores["Data Retention and Security"] ?? ""),
+        csvField(catScores["User Rights and Controls"] ?? ""),
+        csvField(catScores["Transparency and Clarity"] ?? ""),
+        csvField((site.policy_documents_urls ?? []).join("; ")),
       ];
     });
 
@@ -188,9 +198,13 @@ export default function SitesDirectory() {
     const link = document.createElement("a");
     link.href = url;
     link.download = `privacy-peek-sites-${new Date().toISOString().split("T")[0]}.csv`;
+
+    // Revoke the blob URL once the download starts (or after 10s as fallback)
+    const cleanup = () => URL.revokeObjectURL(url);
+    link.addEventListener("click", () => requestAnimationFrame(cleanup));
     link.click();
-    // Delay revocation so the browser has time to initiate the download
-    setTimeout(() => URL.revokeObjectURL(url), 100);
+    // Fallback: if the download was blocked or didn't start, release after 10s
+    setTimeout(cleanup, 10000);
   };
 
   const renderPageNumbers = () => {

--- a/app/stale/page.tsx
+++ b/app/stale/page.tsx
@@ -5,6 +5,7 @@ import { useAction, useQuery } from "convex/react";
 import { api } from "@/convex/_generated/api";
 import { Id } from "@/convex/_generated/dataModel";
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 import { motion } from "framer-motion";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
@@ -32,6 +33,7 @@ import {
 
 export default function StaleAnalysesPage() {
   const allSites = useQuery(api.sites.getSitesBrief, { limit: 500 });
+  const router = useRouter();
   const [batchState, setBatchState] = useState<
     "idle" | "analyzing" | "done"
   >("idle");
@@ -87,6 +89,10 @@ export default function StaleAnalysesPage() {
 
     setBatchState("done");
     setProgress({ current: staleSites.length, total: staleSites.length });
+    // Refresh the page data so Convex refetches and stale status updates
+    setTimeout(() => {
+      router.refresh();
+    }, 500);
   };
 
   const handleIndividualReanalyze = async (siteId: Id<"sites">) => {


### PR DESCRIPTION
## Summary

Found and fixed several edge cases throughout the app that could cause confusing UI states, broken data exports, and unhelpful error messages.

### Changes

**CSV Export (sites page)**
- Proper RFC 4180 escaping for all CSV fields — site names with commas, quotes, or newlines now export correctly instead of breaking column alignment
- Replaced the fragile `setTimeout(revoke, 100ms)` with a download-start event listener plus 10s fallback so the blob URL isn't revoked before the browser initiates the download

**Site Detail Page**
- Added Convex ID format validation for the site ID route parameter — malformed/injected IDs (e.g. `/site/not-an-id`) now return a proper 404 instead of a misleading "This site hasn't been analyzed yet" message

**Compare Page**
- Added a dedicated loading state when sites are selected but data hasn't arrived yet (was showing blank content)
- Added a loading state for the initial "loading available sites" phase
- Removed a duplicate generic loading state that overlapped with the new specific ones

**Search Result Score Display**
- Clamped the score value passed to `ScoreVisualizer` via `getOverallScoreDisplay` — prevents out-of-range [0,100] values from producing unexpected visual rendering

**Stale Analysis Page**
- Auto-refreshes page data after batch re-analyze completes so the updated analyses reflect immediately in the UI (was staying on stale data until manual refresh)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer loading states for comparison pages when selected sites or available sites are still being fetched.
  * Refreshed stale-page data automatically after re-analysis so results update sooner.
* **Bug Fixes**
  * Improved score display handling to show cleaner, safer values in result cards.
  * Blocked invalid site pages from loading when the site ID format is incorrect.
  * Fixed CSV exports so values with commas, quotes, or line breaks are handled correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->