### PR TITLE
feat: add privacy dashboard with charts, score analytics, and UI polish

### DIFF
--- a/app/_components/SearchComponent.tsx
+++ b/app/_components/SearchComponent.tsx
@@ -178,7 +178,8 @@ export default function SearchComponent() {
                     <Search className="absolute left-4 top-1/2 -translate-y-1/2 size-5 text-muted-foreground pointer-events-none" />
                     <Input
                       placeholder="Enter a name or url..."
-                      className="text-lg! text-center h-fit! px-6! py-3! rounded-full pr-10! pl-12!"
+                      className="text-lg! text-center h-fit! px-6! py-3! rounded-full pr-12! pl-12!"
+                      autoFocus
                       {...field}
                     />
                   </div>

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,0 +1,397 @@
+"use client";
+
+import { useQuery } from "convex/react";
+import { api } from "@/convex/_generated/api";
+import Link from "next/link";
+import { motion } from "framer-motion";
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+  Cell,
+} from "recharts";
+import {
+  ArrowLeft,
+  BarChart3Icon,
+  TrendingUpIcon,
+  TrendingDownIcon,
+  AlertTriangle,
+  LoaderCircle,
+  ListIcon,
+  ChartNoAxesColumnIncreasing,
+  Shield,
+  Globe,
+} from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Separator } from "@/components/ui/separator";
+import ScoreVisualizer from "@/components/ui/score-visualizer";
+import {
+  cn,
+  getOverallScoreDisplay,
+  getDomainLabel,
+  formatRelativeTime,
+} from "@/lib/utils";
+
+const DISTRIBUTION_COLORS: Record<string, string> = {
+  "0-19": "hsl(var(--destructive))",
+  "20-39": "hsl(var(--destructive) / 0.7)",
+  "40-59": "hsl(var(--chart-3))",
+  "60-79": "hsl(var(--chart-2))",
+  "80-100": "hsl(var(--chart-1))",
+};
+
+const CATEGORY_COLORS = [
+  "hsl(var(--chart-1))",
+  "hsl(var(--chart-2))",
+  "hsl(var(--chart-3))",
+  "hsl(var(--chart-4))",
+  "hsl(var(--chart-5))",
+];
+
+export default function DashboardPage() {
+  const stats = useQuery(api.sites.getDashboardStats);
+  const allSites = useQuery(api.sites.getSitesBrief, { limit: 200 });
+
+  if (!stats || !allSites) {
+    return (
+      <section className="flex flex-col items-center justify-center min-h-[60dvh] gap-4">
+        <div className="animate-pulse flex flex-col items-center gap-4">
+          <LoaderCircle className="size-8 animate-spin text-muted-foreground" />
+          <p className="text-muted-foreground">Loading dashboard data...</p>
+        </div>
+      </section>
+    );
+  }
+
+  const scoreDistData = [
+    { name: "0-19", value: stats.scoreDistribution[0], fill: DISTRIBUTION_COLORS["0-19"] },
+    { name: "20-39", value: stats.scoreDistribution[1], fill: DISTRIBUTION_COLORS["20-39"] },
+    { name: "40-59", value: stats.scoreDistribution[2], fill: DISTRIBUTION_COLORS["40-59"] },
+    { name: "60-79", value: stats.scoreDistribution[3], fill: DISTRIBUTION_COLORS["60-79"] },
+    { name: "80-100", value: stats.scoreDistribution[4], fill: DISTRIBUTION_COLORS["80-100"] },
+  ];
+
+  const categoryData = stats.categoryAverages.map((cat, i) => ({
+    name: cat.category_name,
+    value: cat.avg_score,
+    fill: CATEGORY_COLORS[i % CATEGORY_COLORS.length],
+  }));
+
+  return (
+    <motion.div
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      transition={{ duration: 0.3 }}
+    >
+      <section className="flex flex-col gap-8 min-h-[60dvh]">
+        {/* Header */}
+        <div className="flex flex-col gap-2">
+          <div className="flex items-center gap-3">
+            <Link
+              href="/"
+              className="text-muted-foreground hover:text-foreground transition-colors"
+              aria-label="Back to home"
+            >
+              <ArrowLeft className="size-5" />
+            </Link>
+            <h2 className="leading-none">Privacy Dashboard</h2>
+          </div>
+          <p className="tagline text-muted-foreground">
+            Visual overview of all analyzed sites — scores, trends, and insights at a glance.
+          </p>
+        </div>
+
+        {/* Summary cards */}
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+          <Card className="border-b-4 border-chart-1/40">
+            <CardContent className="pt-4 pb-3 px-4">
+              <div className="flex items-center gap-2 text-chart-1 mb-1">
+                <ChartNoAxesColumnIncreasing className="size-4" />
+                <span className="text-xs font-medium uppercase tracking-wider">Total Sites</span>
+              </div>
+              <p className="text-2xl font-bold tabular-nums">{stats.total}</p>
+              <p className="text-xs text-muted-foreground">analyzed</p>
+            </CardContent>
+          </Card>
+
+          <Card className="border-b-4">
+            <CardContent className="pt-4 pb-3 px-4">
+              <div className="flex items-center gap-2 text-muted-foreground mb-1">
+                <Shield className="size-4" />
+                <span className="text-xs font-medium uppercase tracking-wider">Avg Score</span>
+              </div>
+              <p className="text-2xl font-bold tabular-nums">{stats.avgScore.toFixed(1)}</p>
+              <p className="text-xs text-muted-foreground">/100 overall</p>
+            </CardContent>
+          </Card>
+
+          <Card className="border-b-4">
+            <CardContent className="pt-4 pb-3 px-4">
+              <div className="flex items-center gap-2 text-muted-foreground mb-1">
+                <Globe className="size-4" />
+                <span className="text-xs font-medium uppercase tracking-wider">Best Score</span>
+              </div>
+              <p className="text-2xl font-bold tabular-nums text-chart-1">
+                {stats.bestSites.length > 0 ? getOverallScoreDisplay(stats.bestSites[0].overall_score) : "—"}
+              </p>
+              <p className="text-xs text-muted-foreground truncate">
+                {stats.bestSites.length > 0 ? getDomainLabel(stats.bestSites[0].site_name) : "—"}
+              </p>
+            </CardContent>
+          </Card>
+
+          <Card className="border-b-4">
+            <CardContent className="pt-4 pb-3 px-4">
+              <div className="flex items-center gap-2 text-destructive mb-1">
+                <AlertTriangle className="size-4" />
+                <span className="text-xs font-medium uppercase tracking-wider">
+                  {stats.staleCount > 0 ? "Stale" : "All Fresh"}
+                </span>
+              </div>
+              <p className="text-2xl font-bold tabular-nums">{stats.staleCount}</p>
+              <p className="text-xs text-muted-foreground">
+                {stats.staleCount === 1 ? "site needs refresh" : stats.staleCount > 0 ? "sites need refresh" : "up to date"}
+              </p>
+            </CardContent>
+          </Card>
+        </div>
+
+        {/* Score Distribution + Category Averages */}
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+          {/* Score Distribution Histogram */}
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2 text-base">
+                <BarChart3Icon className="size-4 text-muted-foreground" />
+                Score Distribution
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              {scoreDistData.some((d) => d.value > 0) ? (
+                <div className="h-64">
+                  <ResponsiveContainer width="100%" height="100%">
+                    <BarChart data={scoreDistData} margin={{ top: 8, right: 8, left: -16, bottom: 4 }}>
+                      <CartesianGrid strokeDasharray="3 3" className="stroke-border/50" />
+                      <XAxis dataKey="name" tick={{ fontSize: 12 }} />
+                      <YAxis allowDecimals={false} tick={{ fontSize: 12 }} />
+                      <Tooltip
+                        contentStyle={{
+                          background: "hsl(var(--card))",
+                          border: "1px solid hsl(var(--border))",
+                          borderRadius: "8px",
+                          fontSize: "13px",
+                        }}
+                        formatter={(value: number, _name: string) => [`${value} site${value !== 1 ? "s" : ""}`]}
+                      />
+                      <Bar dataKey="value" radius={[6, 6, 0, 0]} maxBarSize={60}>
+                        {scoreDistData.map((entry, i) => (
+                          <Cell key={i} fill={entry.fill} />
+                        ))}
+                      </Bar>
+                    </BarChart>
+                  </ResponsiveContainer>
+                </div>
+              ) : (
+                <div className="h-32 flex items-center justify-center text-sm text-muted-foreground">
+                  No data yet — analyze a site to see distribution.
+                </div>
+              )}
+              <div className="flex items-center justify-center gap-4 mt-4 text-xs text-muted-foreground">
+                <span className="flex items-center gap-1">
+                  <span className="size-2.5 rounded-sm bg-[hsl(var(--destructive))]" />
+                  Poor
+                </span>
+                <span className="flex items-center gap-1">
+                  <span className="size-2.5 rounded-sm bg-[hsl(var(--chart-3))]" />
+                  Fair
+                </span>
+                <span className="flex items-center gap-1">
+                  <span className="size-2.5 rounded-sm bg-[hsl(var(--chart-1))]" />
+                  Good
+                </span>
+              </div>
+            </CardContent>
+          </Card>
+
+          {/* Category Averages */}
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2 text-base">
+                <ChartNoAxesColumnIncreasing className="size-4 text-muted-foreground" />
+                Average Category Scores /10
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              {categoryData.length > 0 ? (
+                <div className="h-64">
+                  <ResponsiveContainer width="100%" height="100%">
+                    <BarChart
+                      data={categoryData}
+                      layout="vertical"
+                      margin={{ top: 8, right: 24, left: 0, bottom: 4 }}
+                    >
+                      <CartesianGrid strokeDasharray="3 3" className="stroke-border/50" horizontal={false} />
+                      <XAxis type="number" domain={[0, 10]} tick={{ fontSize: 12 }} />
+                      <YAxis
+                        type="category"
+                        dataKey="name"
+                        tick={{ fontSize: 11 }}
+                        width={130}
+                        tickFormatter={(val: string) =>
+                          val.length > 20 ? val.slice(0, 20) + "…" : val
+                        }
+                      />
+                      <Tooltip
+                        contentStyle={{
+                          background: "hsl(var(--card))",
+                          border: "1px solid hsl(var(--border))",
+                          borderRadius: "8px",
+                          fontSize: "13px",
+                        }}
+                        formatter={(value: number) => [value.toFixed(1) + " /10"]}
+                      />
+                      <Bar dataKey="value" radius={[0, 6, 6, 0]} maxBarSize={24}>
+                        {categoryData.map((entry, i) => (
+                          <Cell key={i} fill={entry.fill} />
+                        ))}
+                      </Bar>
+                    </BarChart>
+                  </ResponsiveContainer>
+                </div>
+              ) : (
+                <div className="h-32 flex items-center justify-center text-sm text-muted-foreground">
+                  No category data yet.
+                </div>
+              )}
+            </CardContent>
+          </Card>
+        </div>
+
+        {/* Best and Worst Sites */}
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+          {/* Best Sites */}
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2 text-base">
+                <TrendingUpIcon className="size-4 text-chart-1" />
+                Top 5 Best
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="pt-0">
+              {stats.bestSites.length > 0 ? (
+                <div className="flex flex-col gap-1">
+                  {stats.bestSites.map((site, i) => {
+                    const safeScore = getOverallScoreDisplay(site.overall_score);
+                    return (
+                      <Link
+                        key={site._id}
+                        href={`/site/${site._id}`}
+                        className={cn(
+                          "flex items-center gap-3 rounded-lg px-3 py-2.5 transition-colors",
+                          "hover:bg-accent",
+                        )}
+                      >
+                        <span className="text-xs font-mono tabular-nums text-muted-foreground w-4 shrink-0">
+                          {i + 1}
+                        </span>
+                        <span className="flex-1 truncate text-sm font-medium">
+                          {site.site_name || "Unnamed Site"}
+                        </span>
+                        <div className="flex items-center gap-2 shrink-0">
+                          <span className="text-sm font-mono tabular-nums text-chart-1">
+                            {safeScore}
+                          </span>
+                          <ScoreVisualizer value={safeScore / 100} displayNumber="" size={24} />
+                        </div>
+                      </Link>
+                    );
+                  })}
+                </div>
+              ) : (
+                <div className="py-8 text-center text-sm text-muted-foreground">
+                  No sites analyzed yet.
+                </div>
+              )}
+            </CardContent>
+          </Card>
+
+          {/* Worst Sites */}
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2 text-base">
+                <TrendingDownIcon className="size-4 text-destructive" />
+                Bottom 5
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="pt-0">
+              {stats.worstSites.length > 0 ? (
+                <div className="flex flex-col gap-1">
+                  {stats.worstSites.map((site, i) => {
+                    const safeScore = getOverallScoreDisplay(site.overall_score);
+                    return (
+                      <Link
+                        key={site._id}
+                        href={`/site/${site._id}`}
+                        className={cn(
+                          "flex items-center gap-3 rounded-lg px-3 py-2.5 transition-colors",
+                          "hover:bg-accent",
+                        )}
+                      >
+                        <span className="text-xs font-mono tabular-nums text-muted-foreground w-4 shrink-0">
+                          {i + 1}
+                        </span>
+                        <span className="flex-1 truncate text-sm font-medium">
+                          {site.site_name || "Unnamed Site"}
+                        </span>
+                        <div className="flex items-center gap-2 shrink-0">
+                          <span className="text-sm font-mono tabular-nums text-destructive">
+                            {safeScore}
+                          </span>
+                          <ScoreVisualizer value={safeScore / 100} displayNumber="" size={24} />
+                        </div>
+                      </Link>
+                    );
+                  })}
+                </div>
+              ) : (
+                <div className="py-8 text-center text-sm text-muted-foreground">
+                  No sites analyzed yet.
+                </div>
+              )}
+            </CardContent>
+          </Card>
+        </div>
+
+        {/* Navigation footer */}
+        <div className="flex flex-wrap items-center gap-3">
+          <Button variant="outline" size="sm" asChild>
+            <Link href="/sites" className="gap-1.5">
+              <ListIcon className="size-3.5" />
+              Browse all sites
+            </Link>
+          </Button>
+          <Button variant="outline" size="sm" asChild>
+            <Link href="/compare" className="gap-1.5">
+              <BarChart3Icon className="size-3.5" />
+              Compare sites
+            </Link>
+          </Button>
+          {stats.staleCount > 0 && (
+            <Button variant="outline" size="sm" asChild>
+              <Link href="/stale" className="gap-1.5">
+                <AlertTriangle className="size-3.5" />
+                Refresh {stats.staleCount} stale
+              </Link>
+            </Button>
+          )}
+        </div>
+      </section>
+    </motion.div>
+  );
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -304,6 +304,7 @@ html {
   height: 100dvh;
   transition: height 0.3s ease-in-out;
   padding: 0;
+  scroll-behavior: smooth;
 
   body {
     height: 100dvh;
@@ -360,13 +361,77 @@ html {
   scrollbar-width: none; /* Firefox */
 }
 
+@keyframes blob-drift {
+  0%,
+  100% {
+    transform: translate(0, 0) rotate(0deg);
+  }
+  33% {
+    transform: translate(30px, -25px) rotate(2deg);
+  }
+  66% {
+    transform: translate(-25px, 20px) rotate(-1deg);
+  }
+}
+
+@keyframes shimmer {
+  0% {
+    background-position: -200% center;
+  }
+  100% {
+    background-position: 200% center;
+  }
+}
+
+@keyframes scale-in-up {
+  from {
+    opacity: 0;
+    transform: scale(0.9) translateY(8px);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1) translateY(0);
+  }
+}
+
+.animate-blob {
+  animation: blob-drift 24s ease-in-out infinite;
+}
+
+.animate-blob-delayed {
+  animation: blob-drift 28s ease-in-out 6s infinite;
+}
+
+.animate-scale-in-up {
+  animation: scale-in-up 0.5s cubic-bezier(0.16, 1, 0.3, 1) both;
+}
+
+.animate-shimmer {
+  background: linear-gradient(
+    90deg,
+    transparent 0%,
+    color-mix(in srgb, var(--muted-foreground) 8%, transparent) 50%,
+    transparent 100%
+  );
+  background-size: 200% 100%;
+  animation: shimmer 2s ease-in-out infinite;
+}
+
 @media (prefers-reduced-motion: reduce) {
   .animate-fade-in-up,
   .animate-fade-in,
-  .animate-scale-in {
+  .animate-scale-in,
+  .animate-scale-in-up,
+  .animate-blob,
+  .animate-blob-delayed,
+  .animate-shimmer {
     animation: none !important;
     opacity: 1 !important;
     transform: none !important;
+  }
+
+  html {
+    scroll-behavior: auto !important;
   }
 
   *,
@@ -375,6 +440,5 @@ html {
     animation-duration: 0.01ms !important;
     animation-iteration-count: 1 !important;
     transition-duration: 0.01ms !important;
-    scroll-behavior: auto !important;
   }
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -51,8 +51,8 @@ export default function RootLayout({
               Skip to main content
             </a>
             <NavBar />
-            <div className="fixed -top-24 -left-24 -z-10 w-128 aspect-square rounded-full bg-gradient-to-br from-primary/10 via-accent/60 to-transparent blur-3xl will-change-transform" />
-            <div className="fixed -bottom-24 -right-24 -z-10 w-128 aspect-square rounded-full bg-gradient-to-tl from-accent/60 via-primary/10 to-transparent blur-3xl will-change-transform" />
+            <div className="fixed -top-24 -left-24 -z-10 w-128 aspect-square rounded-full bg-gradient-to-br from-primary/15 via-accent/60 to-transparent blur-3xl animate-blob" />
+            <div className="fixed -bottom-24 -right-24 -z-10 w-128 aspect-square rounded-full bg-gradient-to-tl from-accent/60 via-primary/15 to-transparent blur-3xl animate-blob-delayed" />
             <ErrorBoundary>
               <main id="main-content" tabIndex={-1}>
                 {children}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -33,8 +33,12 @@ export default function Home() {
       <section className="flex flex-col items-center gap-10 md:gap-14">
         <motion.div
           variants={childVariants}
-          className="w-full flex flex-col items-center gap-2 text-center"
+          className="w-full flex flex-col items-center gap-3 text-center"
         >
+          <span className="inline-flex items-center gap-1.5 rounded-full border bg-accent/50 px-3.5 py-1 text-xs font-medium text-accent-foreground tracking-wide">
+            <span className="size-1.5 rounded-full bg-accent-foreground" />
+            Privacy Policy Scanner
+          </span>
           <h1 className="capitalize leading-none">
             your privacy matters
           </h1>

--- a/components/global/Navbar.tsx
+++ b/components/global/Navbar.tsx
@@ -10,7 +10,7 @@ import {
 import Logo from './Logo';
 import { ModeToggle } from '@/components/ModeToggle';
 import { cn } from '@/lib/utils';
-import { AlertTriangleIcon, BarChart3Icon, ListIcon } from 'lucide-react';
+import { AlertTriangleIcon, BarChart3Icon, ListIcon, LayoutDashboardIcon } from 'lucide-react';
 import { usePathname } from 'next/navigation';
 
 export function NavBar() {
@@ -75,6 +75,22 @@ export function NavBar() {
             >
               <AlertTriangleIcon className="size-4" />
               <span className="hidden sm:inline">Stale</span>
+            </Link>
+          </NavigationMenuLink>
+        </NavigationMenuItem>
+        <NavigationMenuItem>
+          <NavigationMenuLink asChild>
+            <Link
+              href="/dashboard"
+              className={cn(
+                'inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-sm transition-colors',
+                pathname === '/dashboard'
+                  ? 'bg-accent text-accent-foreground'
+                  : 'text-muted-foreground hover:text-foreground hover:bg-accent/50',
+              )}
+            >
+              <LayoutDashboardIcon className="size-4" />
+              <span className="hidden sm:inline">Dashboard</span>
             </Link>
           </NavigationMenuLink>
         </NavigationMenuItem>

--- a/components/global/Navbar.tsx
+++ b/components/global/Navbar.tsx
@@ -37,7 +37,7 @@ export function NavBar() {
               className={cn(
                 'inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-sm transition-colors',
                 pathname === '/sites'
-                  ? 'bg-accent text-accent-foreground'
+                  ? 'bg-accent text-accent-foreground font-medium'
                   : 'text-muted-foreground hover:text-foreground hover:bg-accent/50',
               )}
             >
@@ -53,7 +53,7 @@ export function NavBar() {
               className={cn(
                 'inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-sm transition-colors',
                 pathname === '/compare'
-                  ? 'bg-accent text-accent-foreground'
+                  ? 'bg-accent text-accent-foreground font-medium'
                   : 'text-muted-foreground hover:text-foreground hover:bg-accent/50',
               )}
             >
@@ -69,7 +69,7 @@ export function NavBar() {
               className={cn(
                 'inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-sm transition-colors',
                 pathname === '/stale'
-                  ? 'bg-accent text-accent-foreground'
+                  ? 'bg-accent text-accent-foreground font-medium'
                   : 'text-muted-foreground hover:text-foreground hover:bg-accent/50',
               )}
             >
@@ -85,7 +85,7 @@ export function NavBar() {
               className={cn(
                 'inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-sm transition-colors',
                 pathname === '/dashboard'
-                  ? 'bg-accent text-accent-foreground'
+                  ? 'bg-accent text-accent-foreground font-medium'
                   : 'text-muted-foreground hover:text-foreground hover:bg-accent/50',
               )}
             >

--- a/convex/sites.ts
+++ b/convex/sites.ts
@@ -211,6 +211,82 @@ export const getSitesStats = query({
   },
 });
 
+export const getDashboardStats = query({
+  handler: async (ctx) => {
+    const allSites = await ctx.db.query("sites").collect();
+    const total = allSites.length;
+    if (total === 0) {
+      return {
+        total: 0,
+        avgScore: 0,
+        staleCount: 0,
+        scoreDistribution: [0, 0, 0, 0, 0],
+        categoryAverages: [],
+        bestSites: [],
+        worstSites: [],
+      };
+    }
+
+    // Score distribution buckets: <20, 20-39, 40-59, 60-79, 80-100
+    const scoreDistribution = [0, 0, 0, 0, 0];
+    const sumScores = allSites.reduce((acc, site) => {
+      const score = site.overall_score ?? 0;
+      if (score < 20) scoreDistribution[0]++;
+      else if (score < 40) scoreDistribution[1]++;
+      else if (score < 60) scoreDistribution[2]++;
+      else if (score < 80) scoreDistribution[3]++;
+      else scoreDistribution[4]++;
+      return acc + score;
+    }, 0);
+    const avgScore = total > 0 ? Math.round((sumScores / total) * 100) / 100 : 0;
+
+    // Staleness
+    const now = Date.now();
+    const STALE_MS = 14 * 24 * 60 * 60 * 1000;
+    const staleCount = allSites.filter((s) => {
+      const analyzed = new Date(s.last_analyzed).getTime();
+      return !Number.isNaN(analyzed) && now - analyzed >= STALE_MS;
+    }).length;
+
+    // Category averages
+    const categoryMap = new Map<string, { sum: number; count: number }>();
+    for (const site of allSites) {
+      for (const cat of site.category_scores ?? []) {
+        const entry = categoryMap.get(cat.category_name) ?? { sum: 0, count: 0 };
+        entry.sum += cat.category_score;
+        entry.count++;
+        categoryMap.set(cat.category_name, entry);
+      }
+    }
+    const categoryAverages = Array.from(categoryMap.entries()).map(([name, { sum, count }]) => ({
+      category_name: name,
+      avg_score: Math.round((sum / count) * 10) / 10,
+    }));
+
+    // Best and worst sites
+    const scored = allSites
+      .filter((s) => s.overall_score != null)
+      .map((s) => ({
+        _id: s._id,
+        site_name: s.site_name,
+        overall_score: s.overall_score,
+      }));
+    scored.sort((a, b) => b.overall_score - a.overall_score);
+    const bestSites = scored.slice(0, 5);
+    const worstSites = scored.slice(-5).reverse();
+
+    return {
+      total,
+      avgScore,
+      staleCount,
+      scoreDistribution,
+      categoryAverages,
+      bestSites,
+      worstSites,
+    };
+  },
+});
+
 export const updateSiteAnalysis = internalMutation({
   args: {
     site_id: v.id("sites"),


### PR DESCRIPTION
## Summary

- **Dashboard page** with score distribution histogram, category averages bar chart, best/worst sites lists, and summary stats cards
- **UI/UX polish** across the app: animated background gradient blobs, enhanced hero section with decorative badge, search input autoFocus, improved nav active states, smooth scroll, shimmer loading animation
- **Fixed** stray lockfile in home directory that was confusing Next.js turbopack root detection

## Changes

- `app/dashboard/page.tsx` — new interactive dashboard with recharts visualizations
- `app/globals.css` — blob-drift animation, shimmer loading, smooth scroll, scale-in-up animation, improved reduced-motion support
- `app/layout.tsx` — animated background gradient blobs (24s drift cycle)
- `app/page.tsx` — hero section with decorative "Privacy Policy Scanner" badge, improved spacing
- `app/_components/SearchComponent.tsx` — autoFocus on search input for instant scanning
- `components/global/Navbar.tsx` — font-medium on active nav items for clearer indication

## Test Plan

- [x] `npx next build` passes clean
- [x] No turbopack root warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dashboard page with summary metrics, score distribution, category averages, and top/bottom site lists.
  * Extended navigation to include a dashboard link with active-state highlighting.
  * Added quick actions to browse all sites, compare sites, and refresh stale results when applicable.
* **Bug Fixes**
  * Improved loading behavior by waiting for required dashboard data before rendering.
  * Added empty-state fallbacks for charts and site lists when no data is available.
* **Chores**
  * Updated global styling for smoother scrolling, animations, and reduced-motion behavior; adjusted minor UI spacing and autofocus in search.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->