### PR TITLE
feat: privacy snapshot, radar chart comparison, always-visible reanalyze

### DIFF
--- a/app/_components/quick-stats.tsx
+++ b/app/_components/quick-stats.tsx
@@ -1,0 +1,169 @@
+import { api } from "@/convex/_generated/api";
+import { fetchQuery } from "convex/nextjs";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  ChartNoAxesColumnIncreasing,
+  Shield,
+  AlertTriangle,
+  TrendingUp,
+  TrendingDown,
+} from "lucide-react";
+import Link from "next/link";
+import { getOverallScoreDisplay, getDomainLabel } from "@/lib/utils";
+
+export default async function QuickStats() {
+  if (!process.env.NEXT_PUBLIC_CONVEX_URL) {
+    return null;
+  }
+
+  let stats: {
+    total: number;
+    avgScore: number;
+    staleCount: number;
+    scoreDistribution: number[];
+    categoryAverages: { category_name: string; avg_score: number }[];
+    bestSites: { _id: string; site_name: string; overall_score: number }[];
+    worstSites: { _id: string; site_name: string; overall_score: number }[];
+  };
+
+  try {
+    stats = await fetchQuery(api.sites.getDashboardStats);
+  } catch {
+    console.warn(
+      "Failed to fetch dashboard stats — Convex may be unreachable.",
+    );
+    return null;
+  }
+
+  if (stats.total === 0) {
+    return null;
+  }
+
+  return (
+    <section className="flex flex-col gap-4">
+      <div className="flex flex-col gap-1">
+        <h4>Privacy Snapshot</h4>
+        <p className="text-sm text-muted-foreground">
+          Quick overview of all analyzed sites.
+        </p>
+      </div>
+
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+        {/* Total Sites */}
+        <Card className="border-t-4 border-t-chart-1 shadow-sm">
+          <CardContent className="pt-5 pb-4 px-4">
+            <div className="flex items-center gap-2 text-chart-1 mb-2">
+              <ChartNoAxesColumnIncreasing className="size-4" />
+              <span className="text-xs font-semibold uppercase tracking-wider">
+                Total
+              </span>
+            </div>
+            <p className="text-2xl font-bold tabular-nums tracking-tight">
+              {stats.total}
+            </p>
+            <p className="text-xs text-muted-foreground mt-0.5">
+              sites analyzed
+            </p>
+          </CardContent>
+        </Card>
+
+        {/* Average Score */}
+        <Card className="border-t-4 border-t-chart-2 shadow-sm">
+          <CardContent className="pt-5 pb-4 px-4">
+            <div className="flex items-center gap-2 text-chart-2 mb-2">
+              <Shield className="size-4" />
+              <span className="text-xs font-semibold uppercase tracking-wider">
+                Avg Score
+              </span>
+            </div>
+            <p className="text-2xl font-bold tabular-nums tracking-tight">
+              {Number.isFinite(stats.avgScore)
+                ? stats.avgScore.toFixed(1)
+                : "—"}
+            </p>
+            <p className="text-xs text-muted-foreground mt-0.5">out of 100</p>
+          </CardContent>
+        </Card>
+
+        {/* Stale Count */}
+        <Card className="border-t-4 border-t-destructive shadow-sm">
+          <CardContent className="pt-5 pb-4 px-4">
+            <div className="flex items-center gap-2 text-destructive mb-2">
+              <AlertTriangle className="size-4" />
+              <span className="text-xs font-semibold uppercase tracking-wider">
+                Stale
+              </span>
+            </div>
+            <p className="text-2xl font-bold tabular-nums tracking-tight">
+              {stats.staleCount}
+            </p>
+            <p className="text-xs text-muted-foreground mt-0.5">
+              {stats.staleCount === 1
+                ? "site needs update"
+                : stats.staleCount > 0
+                  ? "sites need updates"
+                  : "all up to date"}
+            </p>
+          </CardContent>
+        </Card>
+
+        {/* Best Score */}
+        <Card className="border-t-4 border-t-chart-3 shadow-sm">
+          <CardContent className="pt-5 pb-4 px-4">
+            <div className="flex items-center gap-2 text-chart-3 mb-2">
+              <TrendingUp className="size-4" />
+              <span className="text-xs font-semibold uppercase tracking-wider">
+                Best Score
+              </span>
+            </div>
+            <p className="text-2xl font-bold tabular-nums tracking-tight text-chart-3">
+              {stats.bestSites.length > 0
+                ? getOverallScoreDisplay(stats.bestSites[0].overall_score)
+                : "—"}
+            </p>
+            <p className="text-xs text-muted-foreground mt-0.5 truncate max-w-full">
+              {stats.bestSites.length > 0
+                ? getDomainLabel(stats.bestSites[0].site_name)
+                : "—"}
+            </p>
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* Quick navigation links */}
+      <div className="flex flex-wrap items-center gap-2">
+        <Link
+          href="/sites"
+          className="text-xs inline-flex items-center gap-1 text-muted-foreground hover:text-foreground transition-colors"
+        >
+          Browse all sites &rarr;
+        </Link>
+        <span className="text-muted-foreground/30">·</span>
+        <Link
+          href="/dashboard"
+          className="text-xs inline-flex items-center gap-1 text-muted-foreground hover:text-foreground transition-colors"
+        >
+          View full dashboard &rarr;
+        </Link>
+        {stats.staleCount > 0 && (
+          <>
+            <span className="text-muted-foreground/30">·</span>
+            <Link
+              href="/stale"
+              className="text-xs inline-flex items-center gap-1 text-amber-600 dark:text-amber-400 hover:text-amber-700 dark:hover:text-amber-300 transition-colors"
+            >
+              <AlertTriangle className="size-3" />
+              Refresh {stats.staleCount} stale
+            </Link>
+          </>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/app/compare/page.tsx
+++ b/app/compare/page.tsx
@@ -46,6 +46,15 @@ import {
 import Link from "next/link";
 import { useSearchParams, useRouter } from "next/navigation";
 import { motion, AnimatePresence } from "framer-motion";
+import {
+  RadarChart,
+  Radar,
+  PolarGrid,
+  PolarAngleAxis,
+  PolarRadiusAxis,
+  ResponsiveContainer,
+  Legend,
+} from "recharts";
 import type { Doc, Id } from "@/convex/_generated/dataModel";
 
 export default function ComparePageWrapper() {
@@ -268,7 +277,86 @@ function ComparePageContent() {
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}
             transition={{ duration: 0.3 }}
+            className="flex flex-col gap-6"
           >
+            {/* Radar Chart */}
+            <div className="w-full">
+              <h3 className="text-lg font-semibold mb-1">
+                Category Comparison
+              </h3>
+              <p className="text-sm text-muted-foreground mb-4">
+                Visual overview of how each site scores across privacy
+                categories.
+              </p>
+              <div className="bg-card rounded-2xl border p-4 sm:p-6">
+                <ResponsiveContainer width="100%" height={360}>
+                  <RadarChart
+                    data={(() => {
+                      const categories = [
+                        "Data Collection",
+                        "Data Sharing",
+                        "Data Retention and Security",
+                        "User Rights and Controls",
+                        "Transparency and Clarity",
+                      ];
+                      return categories.map((cat) => {
+                        const row: Record<string, string | number> = {
+                          category: cat,
+                        };
+                        for (const site of selectedSites) {
+                          const cs = (
+                            site.category_scores ?? []
+                          ).find(
+                            (c: { category_name: string }) =>
+                              c.category_name === cat,
+                          );
+                          row[site.site_name ?? "Unnamed"] = cs
+                            ? cs.category_score
+                            : 0;
+                        }
+                        return row;
+                      });
+                    })()}
+                  >
+                    <PolarGrid className="stroke-border/50" />
+                    <PolarAngleAxis
+                      dataKey="category"
+                      tick={{ fontSize: 11 }}
+                      className="fill-muted-foreground"
+                    />
+                    <PolarRadiusAxis
+                      angle={30}
+                      domain={[0, 10]}
+                      tick={{ fontSize: 10 }}
+                      className="fill-muted-foreground"
+                    />
+                    {selectedSites.map(
+                      (
+                        site: { _id: string; site_name?: string; category_scores?: Array<{ category_name: string; category_score: number }> },
+                        i: number,
+                      ) => (
+                        <Radar
+                          key={site._id}
+                          name={site.site_name ?? "Unnamed"}
+                          dataKey={site.site_name ?? "Unnamed"}
+                          stroke={`hsl(var(--chart-${(i % 5) + 1}))`}
+                          fill={`hsl(var(--chart-${(i % 5) + 1}))`}
+                          fillOpacity={0.15}
+                          strokeWidth={2}
+                        />
+                      ),
+                    )}
+                    <Legend
+                      wrapperStyle={{
+                        fontSize: "12px",
+                        paddingTop: "8px",
+                      }}
+                    />
+                  </RadarChart>
+                </ResponsiveContainer>
+              </div>
+            </div>
+
             <ComparisonGrid sites={selectedSites} onRemove={removeSite} />
           </motion.div>
         )}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,6 +2,7 @@
 import { motion } from 'framer-motion';
 import RecentSites from './_components/recent-sites';
 import SearchComponent from './_components/SearchComponent';
+import QuickStats from './_components/quick-stats';
 
 const containerVariants = {
   hidden: { opacity: 0 },
@@ -51,6 +52,13 @@ export default function Home() {
           <SearchComponent />
         </motion.div>
       </section>
+
+      <motion.div
+        variants={childVariants}
+        className="w-full mt-10"
+      >
+        <QuickStats />
+      </motion.div>
 
       <motion.div
         variants={childVariants}

--- a/app/site/[id]/page.tsx
+++ b/app/site/[id]/page.tsx
@@ -243,11 +243,9 @@ export default async function SitePage({ params }: SitePageProps) {
             Compare with another site
           </Link>
 
-          {stale && (
-            <div className="w-full border-t pt-4">
-              <ReanalyzeButton siteId={id} />
-            </div>
-          )}
+          <div className="w-full border-t pt-4">
+            <ReanalyzeButton siteId={id} />
+          </div>
         </div>
       </div>
     </section>


### PR DESCRIPTION
## Summary

Three UX improvements that make the app more useful at a glance:

### 1. Quick Stats Section (Home Page)
Adds a "Privacy Snapshot" section above the recent sites list showing total sites analyzed, average score, stale count, and best score with site name. Includes quick navigation links to browse all sites, view full dashboard, or refresh stale analyses.

### 2. Always-Visible Re-Analyze Button (Site Detail)
The re-analyze button is now always shown on the site detail page instead of only showing when the analysis is stale. Users can force a fresh analysis whenever they want.

### 3. Radar Chart Comparison (Compare Page)
When comparing 2+ sites, a radar/spider chart visualizes category score differences across all five privacy categories (Data Collection, Data Sharing, Data Retention & Security, User Rights & Controls, Transparency & Clarity). Each site is a separate colored polygon, making score patterns easy to compare at a glance.

## Testing
- `npx next build` passes cleanly
- All 9 pages generate without errors